### PR TITLE
Fix start command quoting

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -50,7 +50,7 @@ timeout /t 8 /nobreak >nul
 
 REM Open the application
 echo 🌐 Opening Audio Chat Studio...
-start http://127.0.0.1:5174
+start "" http://127.0.0.1:5174
 
 echo.
 echo ✅ Audio Chat Studio Started Successfully!


### PR DESCRIPTION
## Summary
- escape window title with empty string when opening browser

## Testing
- `python test_venv_python.py`

------
https://chatgpt.com/codex/tasks/task_e_6888fb0001c8832c90a694815ef6e01a