### PR TITLE
Fix active model fetch options

### DIFF
--- a/frontend/electron-app/src/renderer/pages/llm-page.tsx
+++ b/frontend/electron-app/src/renderer/pages/llm-page.tsx
@@ -127,7 +127,7 @@ export const LLMPage: React.FC = () => {
 
   const handleSetActiveModel = async (modelId: string) => {
     try {
-      const response = await fetch('/api/llm/active-model');
+      const response = await fetch('/api/llm/active-model', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ model_id: modelId }),


### PR DESCRIPTION
## Summary
- close fetch argument in `LLMPage`

## Testing
- `npm --prefix frontend/electron-app run lint` *(fails: ESLint config missing)*
- `npm --prefix frontend/electron-app run type-check` *(fails: cannot find modules & JSX Intrinsic elements)*

------
https://chatgpt.com/codex/tasks/task_e_688902752f34832c90c9991c2e18af01