### PR TITLE
Set default LLM model on startup

### DIFF
--- a/backend/services/ai/llm_service.py
+++ b/backend/services/ai/llm_service.py
@@ -1,6 +1,7 @@
 import os
 import json
 import sqlite3
+import logging
 from datetime import datetime
 from typing import List, Dict, Any, Optional, Tuple
 
@@ -21,6 +22,8 @@ except ImportError:
 from backend.services.utils.api_key_manager import APIKeyManager
 from backend.services.ai.providers.provider_factory import ProviderFactory
 from backend.services.ai.providers.base_provider import BaseProvider, ProviderResponse
+
+logger = logging.getLogger(__name__)
 
 
 class LLMService:
@@ -63,9 +66,17 @@ class LLMService:
 
         # Provider instance cache
         self._provider_instances: Dict[str, BaseProvider] = {}
-        
+
         # טעינת ספקים ברירת מחדל
         self._init_default_providers()
+
+        # Ensure there is an active model after initialization
+        active = self.get_active_model()
+        if not active:
+            self.set_active_model("local-gemma-3-4b-it")
+            active = self.get_active_model()
+        if active:
+            logger.info(f"Active model set to {active.id}")
     
     def _init_db(self) -> None:
         """יצירת מסד נתונים אם לא קיים"""


### PR DESCRIPTION
## Summary
- configure logging for `LLMService`
- ensure initialization picks a default active model

## Testing
- `python -m py_compile backend/services/ai/llm_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891745a820832ca44f73656a169240