### PR TITLE
Add automatic Gemma model downloader

### DIFF
--- a/backend/services/ai/providers/__init__.py
+++ b/backend/services/ai/providers/__init__.py
@@ -8,6 +8,7 @@ from .anthropic_provider import AnthropicProvider
 from .google_provider import GoogleProvider
 from .cohere_provider import CohereProvider
 from .huggingface_provider import HuggingFaceProvider
+from .local_gemma_provider import LocalGemmaProvider
 
 __all__ = [
     'BaseProvider',
@@ -16,5 +17,6 @@ __all__ = [
     'AnthropicProvider',
     'GoogleProvider',
     'CohereProvider',
-    'HuggingFaceProvider'
+    'HuggingFaceProvider',
+    'LocalGemmaProvider'
 ]

--- a/backend/services/ai/providers/gemma_utils.py
+++ b/backend/services/ai/providers/gemma_utils.py
@@ -1,0 +1,26 @@
+from typing import Optional, Tuple
+from huggingface_hub import HfApi, snapshot_download
+
+
+def download_latest_gemma_model(cache_dir: str | None = None) -> Tuple[Optional[str], Optional[str]]:
+    """Download the latest ``google/gemma-*`` model from Hugging Face.
+
+    Args:
+        cache_dir: Optional directory to download the model into.
+
+    Returns:
+        A tuple of ``(local_path, model_id)`` where ``local_path`` is the path
+        to the downloaded snapshot and ``model_id`` is the Hugging Face model
+        identifier. ``None`` is returned for both values if no Gemma model is
+        found.
+    """
+    api = HfApi()
+    models = api.list_models(author="google", search="gemma-")
+    gemma_models = [m for m in models if m.modelId.startswith("google/gemma-")]
+    if not gemma_models:
+        return None, None
+
+    latest = max(gemma_models, key=lambda m: m.lastModified)
+    repo_id = latest.modelId
+    local_path = snapshot_download(repo_id=repo_id, cache_dir=cache_dir)
+    return local_path, repo_id


### PR DESCRIPTION
## Summary
- create helper to pull the newest `google/gemma-*` model via `huggingface_hub`
- teach `LocalGemmaProvider` to load models from local paths
- store downloaded Gemma path and version in the DB
- ensure the latest Gemma release is available during `LLMService` init
- expose `LocalGemmaProvider` in provider package

## Testing
- `python -m py_compile backend/services/ai/providers/gemma_utils.py backend/services/ai/providers/local_gemma_provider.py backend/services/ai/llm_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6889175affe4832ca840e83e796e369a