### PR TITLE
Fix service imports

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -2,6 +2,12 @@
 
 # Core services that should always be available
 try:
+    from .utils.chat_service import ChatService, ChatMessage, ChatSession
+except ImportError:
+    ChatService = None
+    ChatMessage = None
+    ChatSession = None
+try:
     from .llm_service import LLMService
 except ImportError:
     LLMService = None


### PR DESCRIPTION
## Summary
- import chat utils in `backend.services` before exposing via `__all__`

## Testing
- `pytest -q`
- `python -c "import backend.services as s; print('ChatService defined?', hasattr(s, 'ChatService'))"`

------
https://chatgpt.com/codex/tasks/task_e_688a1bb0b62c832c83e88ffdc90fcd4a