### PR TITLE
Implement chat data models

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class ChatSession:
+    """Chat session metadata."""
+
+    id: str
+    title: str
+    model_id: str
+    user_id: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+    message_count: int
+    is_archived: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "model_id": self.model_id,
+            "user_id": self.user_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "message_count": self.message_count,
+            "is_archived": self.is_archived,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChatSession":
+        return cls(
+            id=data["id"],
+            title=data["title"],
+            model_id=data["model_id"],
+            user_id=data.get("user_id"),
+            created_at=datetime.fromisoformat(data["created_at"]),
+            updated_at=datetime.fromisoformat(data["updated_at"]),
+            message_count=data["message_count"],
+            is_archived=data.get("is_archived", False),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass
+class Message:
+    """Single chat message."""
+
+    id: str
+    session_id: str
+    role: str  # "user", "assistant", "system"
+    content: str
+    timestamp: datetime
+    model_id: Optional[str] = None
+    tokens_used: Optional[int] = None
+    response_time: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "session_id": self.session_id,
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp.isoformat(),
+            "model_id": self.model_id,
+            "tokens_used": self.tokens_used,
+            "response_time": self.response_time,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Message":
+        return cls(
+            id=data["id"],
+            session_id=data["session_id"],
+            role=data["role"],
+            content=data["content"],
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            model_id=data.get("model_id"),
+            tokens_used=data.get("tokens_used"),
+            response_time=data.get("response_time"),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass
+class ChatResponse:
+    """Response from the model for a chat message."""
+
+    content: str
+    model_id: str
+    tokens_used: int
+    response_time: float
+    success: bool
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "content": self.content,
+            "model_id": self.model_id,
+            "tokens_used": self.tokens_used,
+            "response_time": self.response_time,
+            "success": self.success,
+            "error_message": self.error_message,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChatResponse":
+        return cls(
+            content=data["content"],
+            model_id=data["model_id"],
+            tokens_used=data["tokens_used"],
+            response_time=data["response_time"],
+            success=data["success"],
+            error_message=data.get("error_message"),
+            metadata=data.get("metadata", {}),
+        )

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from backend.models.chat import ChatSession, Message, ChatResponse
+
+
+def test_chat_session_serialization():
+    now = datetime.now()
+    session = ChatSession(
+        id="s1",
+        title="Test Session",
+        model_id="model-1",
+        user_id="user-123",
+        created_at=now,
+        updated_at=now,
+        message_count=3,
+        is_archived=True,
+        metadata={"foo": "bar"},
+    )
+
+    data = session.to_dict()
+    assert data["id"] == "s1"
+    assert data["created_at"] == now.isoformat()
+    restored = ChatSession.from_dict(data)
+    assert restored == session
+
+
+def test_message_serialization():
+    now = datetime.now()
+    msg = Message(
+        id="m1",
+        session_id="s1",
+        role="user",
+        content="hello",
+        timestamp=now,
+        model_id="model-1",
+        tokens_used=10,
+        response_time=0.4,
+        metadata={"a": 1},
+    )
+    data = msg.to_dict()
+    assert data["timestamp"] == now.isoformat()
+    restored = Message.from_dict(data)
+    assert restored == msg
+
+
+def test_chat_response_serialization():
+    resp = ChatResponse(
+        content="hi",
+        model_id="model-1",
+        tokens_used=5,
+        response_time=0.2,
+        success=True,
+        metadata={"x": "y"},
+    )
+    data = resp.to_dict()
+    assert data["success"] is True
+    restored = ChatResponse.from_dict(data)
+    assert restored == resp


### PR DESCRIPTION
## Summary
- implement dataclasses `ChatSession`, `Message`, and `ChatResponse`
- add serialization helpers
- add unit tests for new models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1bb9c454832c93c0813e15017dce