### PR TITLE
Implement basic chat services

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,8 @@
+from .chat import (
+    ChatSession,
+    Message,
+    ChatResponse,
+    ChatError,
+    SessionNotFoundError,
+    ModelNotAvailableError,
+)

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, Dict, Any
+import json
+
+
+@dataclass
+class ChatSession:
+    id: str
+    title: str
+    model_id: str
+    user_id: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+    message_count: int
+    is_archived: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "model_id": self.model_id,
+            "user_id": self.user_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "message_count": self.message_count,
+            "is_archived": self.is_archived,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_row(cls, row: tuple) -> "ChatSession":
+        return cls(
+            id=row[0],
+            title=row[1],
+            model_id=row[2],
+            user_id=row[3],
+            created_at=datetime.fromisoformat(row[4]),
+            updated_at=datetime.fromisoformat(row[5]),
+            message_count=row[6],
+            is_archived=bool(row[7]),
+            metadata=json.loads(row[8]) if row[8] else {},
+        )
+
+
+@dataclass
+class Message:
+    id: str
+    session_id: str
+    role: str  # "user", "assistant", "system"
+    content: str
+    timestamp: datetime
+    model_id: Optional[str] = None
+    tokens_used: Optional[int] = None
+    response_time: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "session_id": self.session_id,
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp.isoformat(),
+            "model_id": self.model_id,
+            "tokens_used": self.tokens_used,
+            "response_time": self.response_time,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_row(cls, row: tuple) -> "Message":
+        return cls(
+            id=row[0],
+            session_id=row[1],
+            role=row[2],
+            content=row[3],
+            timestamp=datetime.fromisoformat(row[4]),
+            model_id=row[5],
+            tokens_used=row[6],
+            response_time=row[7],
+            metadata=json.loads(row[8]) if row[8] else {},
+        )
+
+
+@dataclass
+class ChatResponse:
+    content: str
+    model_id: str
+    tokens_used: int
+    response_time: float
+    success: bool
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "content": self.content,
+            "model_id": self.model_id,
+            "tokens_used": self.tokens_used,
+            "response_time": self.response_time,
+            "success": self.success,
+            "error_message": self.error_message,
+            "metadata": self.metadata,
+        }
+
+
+class ChatError(Exception):
+    """Base exception for chat-related errors."""
+
+
+class SessionNotFoundError(ChatError):
+    """Raised when a session cannot be found."""
+
+
+class ModelNotAvailableError(ChatError):
+    """Raised when no model is available for chat generation."""

--- a/backend/services/ai/__init__.py
+++ b/backend/services/ai/__init__.py
@@ -1,0 +1,8 @@
+from typing import TYPE_CHECKING
+
+from .chat_service import ChatService
+from .session_service import SessionService
+from .chat_history_service import ChatHistoryService
+
+if TYPE_CHECKING:
+    from .llm_service import LLMService

--- a/backend/services/ai/chat_history_service.py
+++ b/backend/services/ai/chat_history_service.py
@@ -1,0 +1,107 @@
+import json
+import os
+import sqlite3
+import logging
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from backend.models import Message
+
+logger = logging.getLogger(__name__)
+
+
+class ChatHistoryService:
+    """Store and retrieve chat messages"""
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            app_dir = os.path.join(os.path.expanduser("~"), ".audio_chat_qt")
+            os.makedirs(app_dir, exist_ok=True)
+            db_path = os.path.join(app_dir, "chat_history.db")
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS chat_messages (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                model_id TEXT,
+                tokens_used INTEGER,
+                response_time REAL,
+                metadata TEXT DEFAULT '{}',
+                FOREIGN KEY(session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def save_message(self, session_id: str, message: Message) -> str:
+        if not message.id:
+            message.id = str(uuid.uuid4())
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO chat_messages VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                message.id,
+                session_id,
+                message.role,
+                message.content,
+                message.timestamp.isoformat(),
+                message.model_id,
+                message.tokens_used,
+                message.response_time,
+                json.dumps(message.metadata),
+            ),
+        )
+        conn.commit()
+        conn.close()
+        logger.info(f"Saved message {message.id} to session {session_id}")
+        return message.id
+
+    def get_session_messages(self, session_id: str, limit: int = None, offset: int = 0) -> List[Message]:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        query = "SELECT * FROM chat_messages WHERE session_id = ? ORDER BY timestamp ASC"
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            cursor.execute(query, (session_id, limit, offset))
+        else:
+            cursor.execute(query, (session_id,))
+        rows = cursor.fetchall()
+        conn.close()
+        return [Message.from_row(r) for r in rows]
+
+    def search_messages(self, query: str, user_id: str = None, session_id: str = None) -> List[Message]:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        sql = "SELECT m.* FROM chat_messages m JOIN chat_sessions s ON m.session_id = s.id WHERE m.content LIKE ?"
+        params = [f"%{query}%"]
+        if user_id:
+            sql += " AND s.user_id = ?"
+            params.append(user_id)
+        if session_id:
+            sql += " AND m.session_id = ?"
+            params.append(session_id)
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+        conn.close()
+        return [Message.from_row(r) for r in rows]
+
+    def export_session(self, session_id: str, format: str = "json") -> str:
+        messages = self.get_session_messages(session_id)
+        data = [m.to_dict() for m in messages]
+        if format == "json":
+            return json.dumps(data, ensure_ascii=False, indent=2)
+        raise ValueError("Unsupported export format")

--- a/backend/services/ai/chat_service.py
+++ b/backend/services/ai/chat_service.py
@@ -1,0 +1,78 @@
+import logging
+import time
+from typing import List
+from datetime import datetime
+
+from backend.models import Message, ChatResponse, ModelNotAvailableError, SessionNotFoundError
+from typing import TYPE_CHECKING
+
+from .session_service import SessionService
+from .chat_history_service import ChatHistoryService
+
+if TYPE_CHECKING:
+    from backend.services.ai.llm_service import LLMService
+
+logger = logging.getLogger(__name__)
+
+
+class ChatService:
+    """High level chat orchestration"""
+
+    def __init__(self, llm_service: "LLMService", session_service: SessionService, history_service: ChatHistoryService):
+        self.llm_service = llm_service
+        self.session_service = session_service
+        self.history_service = history_service
+
+    def _build_context(self, session_id: str, limit: int = 10) -> List[dict]:
+        messages = self.history_service.get_session_messages(session_id, limit=limit)
+        return [{"role": m.role, "content": m.content} for m in messages]
+
+    def send_message(self, session_id: str, message: str, user_id: str = None) -> ChatResponse:
+        session = self.session_service.get_session(session_id)
+        if not session:
+            logger.error(f"Session {session_id} not found")
+            raise SessionNotFoundError(f"Session {session_id} not found")
+
+        context = self._build_context(session_id)
+        context.append({"role": "user", "content": message})
+
+        start = time.time()
+        provider_resp = self.llm_service.generate_chat_response(context)
+        if not provider_resp or not provider_resp.success:
+            error_msg = provider_resp.error_message if provider_resp else "no response"
+            logger.error(f"LLM generation failed: {error_msg}")
+            raise ModelNotAvailableError(error_msg)
+
+        elapsed = time.time() - start
+        response = ChatResponse(
+            content=provider_resp.content,
+            model_id=provider_resp.model_used,
+            tokens_used=provider_resp.tokens_used,
+            response_time=elapsed,
+            success=True,
+            metadata=provider_resp.metadata,
+        )
+
+        user_msg = Message(
+            id="",
+            session_id=session_id,
+            role="user",
+            content=message,
+            timestamp=datetime.utcnow(),
+        )
+        self.history_service.save_message(session_id, user_msg)
+
+        ai_msg = Message(
+            id="",
+            session_id=session_id,
+            role="assistant",
+            content=response.content,
+            timestamp=datetime.utcnow(),
+            model_id=provider_resp.model_used,
+            tokens_used=provider_resp.tokens_used,
+            response_time=provider_resp.response_time,
+        )
+        self.history_service.save_message(session_id, ai_msg)
+
+        self.session_service.increment_message_count(session_id, 2)
+        return response

--- a/backend/services/ai/session_service.py
+++ b/backend/services/ai/session_service.py
@@ -1,0 +1,145 @@
+import json
+import os
+import sqlite3
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional, List
+
+from backend.models import ChatSession, SessionNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class SessionService:
+    """Manage chat sessions"""
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            app_dir = os.path.join(os.path.expanduser("~"), ".audio_chat_qt")
+            os.makedirs(app_dir, exist_ok=True)
+            db_path = os.path.join(app_dir, "chat_history.db")
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS chat_sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                model_id TEXT NOT NULL,
+                user_id TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                message_count INTEGER DEFAULT 0,
+                is_archived BOOLEAN DEFAULT FALSE,
+                metadata TEXT DEFAULT '{}'
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def create_session(self, title: str = None, model_id: str = None, user_id: str = None) -> ChatSession:
+        session_id = str(uuid.uuid4())
+        now = datetime.utcnow()
+        session = ChatSession(
+            id=session_id,
+            title=title or "New Chat",
+            model_id=model_id or "default",
+            user_id=user_id,
+            created_at=now,
+            updated_at=now,
+            message_count=0,
+        )
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO chat_sessions VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                session.id,
+                session.title,
+                session.model_id,
+                session.user_id,
+                session.created_at.isoformat(),
+                session.updated_at.isoformat(),
+                session.message_count,
+                int(session.is_archived),
+                json.dumps(session.metadata),
+            ),
+        )
+        conn.commit()
+        conn.close()
+        logger.info(f"Created session {session.id}")
+        return session
+
+    def get_session(self, session_id: str) -> Optional[ChatSession]:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM chat_sessions WHERE id = ?", (session_id,))
+        row = cursor.fetchone()
+        conn.close()
+        if not row:
+            return None
+        return ChatSession.from_row(row)
+
+    def list_user_sessions(self, user_id: str = None, limit: int = 50) -> List[ChatSession]:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        if user_id:
+            cursor.execute(
+                "SELECT * FROM chat_sessions WHERE user_id = ? ORDER BY updated_at DESC LIMIT ?",
+                (user_id, limit),
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM chat_sessions ORDER BY updated_at DESC LIMIT ?",
+                (limit,),
+            )
+        rows = cursor.fetchall()
+        conn.close()
+        return [ChatSession.from_row(r) for r in rows]
+
+    def update_session(self, session_id: str, **updates) -> bool:
+        if not updates:
+            return False
+        fields = []
+        values = []
+        for key, value in updates.items():
+            if key == "metadata":
+                value = json.dumps(value)
+            fields.append(f"{key} = ?")
+            values.append(value)
+        values.append(session_id)
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            f"UPDATE chat_sessions SET {', '.join(fields)}, updated_at = ? WHERE id = ?",
+            (*values[:-1], datetime.utcnow().isoformat(), values[-1]),
+        )
+        success = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return success
+
+    def delete_session(self, session_id: str) -> bool:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM chat_sessions WHERE id = ?", (session_id,))
+        success = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return success
+
+    def increment_message_count(self, session_id: str, count: int = 1) -> None:
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE chat_sessions SET message_count = message_count + ?, updated_at = ? WHERE id = ?",
+            (count, datetime.utcnow().isoformat(), session_id),
+        )
+        conn.commit()
+        conn.close()

--- a/tests/unit/test_chat_services.py
+++ b/tests/unit/test_chat_services.py
@@ -1,0 +1,75 @@
+import os
+import unittest
+from tempfile import TemporaryDirectory
+from datetime import datetime
+
+from backend.services.ai.chat_service import ChatService
+from backend.services.ai.session_service import SessionService
+from backend.services.ai.chat_history_service import ChatHistoryService
+from backend.models import Message
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DummyResponse:
+    content: str
+    tokens_used: int
+    cost: float
+    response_time: float
+    model_used: str
+    success: bool = True
+    error_message: str = ""
+    metadata: dict = field(default_factory=dict)
+
+
+class DummyLLMService:
+    def __init__(self):
+        # do not call parent init
+        pass
+
+    def generate_chat_response(self, messages):
+        return DummyResponse(
+            content="pong",
+            tokens_used=1,
+            cost=0.0,
+            response_time=0.01,
+            model_used="dummy",
+            success=True,
+        )
+
+
+class ChatServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = TemporaryDirectory()
+        db_path = os.path.join(self.temp_dir.name, "chat.db")
+        self.session_service = SessionService(db_path)
+        self.history_service = ChatHistoryService(db_path)
+        self.llm_service = DummyLLMService()
+        self.chat_service = ChatService(self.llm_service, self.session_service, self.history_service)
+        self.session = self.session_service.create_session(title="test", model_id="dummy")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_create_and_get_session(self):
+        fetched = self.session_service.get_session(self.session.id)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(fetched.title, "test")
+
+    def test_save_and_load_messages(self):
+        msg = Message(id="1", session_id=self.session.id, role="user", content="hi", timestamp=datetime.utcnow())
+        self.history_service.save_message(self.session.id, msg)
+        msgs = self.history_service.get_session_messages(self.session.id)
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0].content, "hi")
+
+    def test_send_message(self):
+        response = self.chat_service.send_message(self.session.id, "ping")
+        self.assertTrue(response.success)
+        msgs = self.history_service.get_session_messages(self.session.id)
+        self.assertEqual(len(msgs), 2)  # user + assistant
+        self.assertEqual(msgs[1].role, "assistant")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add dataclasses for chat messages and sessions
- implement ChatService, SessionService and ChatHistoryService
- provide unit tests for chat services

## Testing
- `python -m unittest discover -v tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_688a1bc327ac832cbbc900431381debf