### PR TITLE
Add Pydantic schemas for chat endpoints

### DIFF
--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,0 +1,21 @@
+from typing import Optional, Dict, Any
+from pydantic import BaseModel
+
+
+class SendMessageRequest(BaseModel):
+    session_id: str
+    message: str
+    user_id: Optional[str] = None
+
+
+class SessionCreateRequest(BaseModel):
+    title: Optional[str] = None
+    model_id: Optional[str] = None
+    user_id: Optional[str] = None
+
+
+class SessionUpdateRequest(BaseModel):
+    title: Optional[str] = None
+    model_id: Optional[str] = None
+    is_archived: Optional[bool] = None
+    metadata: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- add `backend/api/schemas.py` with request models for upcoming chat endpoints

## Testing
- `PYTHONPATH=. pytest -q tests/unit` *(fails: ModuleNotFoundError or assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d5ea53c832c9f0d85ca7083aa91