### PR TITLE
Update service initialization with chat services

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -24,6 +24,9 @@ def initialize_services():
         from backend.services.storage.file_upload import FileUploadService
         from backend.services.audio.metadata import AudioMetadataService
         from backend.services.audio.editing import AudioEditingService
+        from backend.services.ai.session_service import SessionService
+        from backend.services.ai.chat_history_service import ChatHistoryService
+        from backend.services.ai.chat_service import ChatService
         
         # Try to initialize services one by one
         services['file_upload_service'] = FileUploadService()
@@ -43,6 +46,14 @@ def initialize_services():
         except Exception as e:
             print(f"⚠️ LLM service failed to initialize: {e}")
             services['llm_service'] = None
+
+        services['session_service'] = SessionService()
+        services['chat_history_service'] = ChatHistoryService()
+        services['chat_service'] = ChatService(
+            llm_service=services['llm_service'],
+            session_service=services['session_service'],
+            history_service=services['chat_history_service'],
+        )
         
         # Command processor depends on other services
         try:
@@ -103,6 +114,9 @@ audio_editing_service = services['audio_editing_service']
 file_upload_service = services['file_upload_service']
 audio_metadata_service = services['audio_metadata_service']
 audio_command_processor = services['audio_command_processor']
+session_service = services['session_service']
+chat_history_service = services['chat_history_service']
+chat_service = services['chat_service']
 
 # --- FastAPI App Initialization ---
 app = create_app()


### PR DESCRIPTION
## Summary
- load chat services during initialization
- expose session, chat history, and chat services as globals

## Testing
- `PYTHONPATH=. pytest -q tests/unit/test_chat_service.py::TestChatService::test_send_message_success`
- `PYTHONPATH=. pytest -q tests/unit` *(fails: AssertionError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d60ebe0832c82615cedad0cad28