### PR TITLE
Remove duplicate MessageRole enum

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -23,12 +23,6 @@ class MessageType(Enum):
     FILE = "file"
 
 
-class MessageRole(Enum):
-    """Message role types"""
-    USER = "user"
-    ASSISTANT = "assistant"
-    SYSTEM = "system"
-
 
 class SessionStatus(Enum):
     """Session status types"""


### PR DESCRIPTION
## Summary
- delete redundant `MessageRole` definition in `backend/models/chat.py`

## Testing
- `pytest -q tests/unit/test_chat_models.py` *(fails: Message.role is Enum)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d62998c832c884a979360111ad0