### PR TITLE
Fix chat exception imports

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, File, UploadFile, Form, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from backend.models.chat import SessionNotFoundError, ModelNotAvailableError
 
 
 class SendMessageRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add missing `SessionNotFoundError` and `ModelNotAvailableError` import in `backend/api/main.py`

## Testing
- `PYTHONPATH=. pytest -q tests/unit` *(fails: several tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688a3d2431b8832c9ad1d7a006c5160b