### PR TITLE
Add SSE streaming support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 pydantic>=2.5.0
 python-multipart>=0.0.6
+sse-starlette>=1.6.1
 
 # Audio processing
 librosa>=0.10.0


### PR DESCRIPTION
## Summary
- add `sse-starlette` for streaming responses
- implement `LLMService.stream_chat_response` with optional timeout
- enhance `ChatService.stream_message` with disconnect checks
- update `/api/chat/stream` to return `EventSourceResponse`
- test cancellation logic in `ChatService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest -q tests/unit/test_chat_service.py::TestChatService::test_stream_message_cancelled -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688a420a24e0832c993dcc0a683ea5de