### PR TITLE
Document SSE streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ frontend/electron-app/src/
 | `POST` | `/api/audio/command/execute` | ביצוע פקודה |
 
 למידע על Endpoints של מערכת הצ'אט ראו `docs/development/chat-api-guide.md`.
+המסמך כולל כעת גם סעיף **"Streaming with SSE"** המתאר כיצד לקרוא את `/api/chat/stream` כ־`text/event-stream`.
 
 ## 🛠️ פתרון בעיות
 

--- a/docs/development/chat-api-guide.md
+++ b/docs/development/chat-api-guide.md
@@ -42,3 +42,29 @@ Update example:
 ```
 
 Streaming behaviour is only supported by `/api/chat/stream` and returns incremental text chunks until the model finishes responding.
+
+## Streaming with SSE
+
+The `/api/chat/stream` endpoint can also be consumed using **Server Sent Events** (SSE).  When called, the server responds with the `text/event-stream` content type and sends chunks of text as the model generates them.
+
+Example request using `curl`:
+
+```bash
+curl -N -X POST http://localhost:5000/api/chat/stream \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "123e4567", "message": "Hello"}'
+```
+
+Read each event until you receive `[DONE]` which signals the end of the stream.  A typical sequence looks like:
+
+```
+data: Hello
+
+data:  there
+
+data:  friend
+
+data: [DONE]
+```
+
+If an error occurs the server will send an `event: error` block containing details so clients should listen for that event as well.


### PR DESCRIPTION
## Summary
- document Server Sent Events for `/api/chat/stream`
- reference new SSE docs from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a8d23808c832c81a452c7efd01773