### PR TITLE
Fix stream message count increment

### DIFF
--- a/backend/services/ai/chat_service.py
+++ b/backend/services/ai/chat_service.py
@@ -161,7 +161,8 @@ class ChatService:
                 response_time=response_time,
             )
             self.history_service.save_message(session_id, ai_msg)
-            self.session_service.increment_message_count(session_id, 1)  # Only increment for AI message
+            # Increment count for both the user message and the AI response
+            self.session_service.increment_message_count(session_id, 2)
             
         except asyncio.CancelledError:
             logger.info("Streaming cancelled due to client disconnect")

--- a/tests/unit/test_chat_service.py
+++ b/tests/unit/test_chat_service.py
@@ -169,9 +169,14 @@ class TestChatService:
         
         # Verify session was retrieved
         mock_session_service.get_session.assert_called_once_with("test-session")
-        
+
         # Verify messages were saved
         assert mock_history_service.save_message.call_count == 2  # User + AI message
+
+        # Verify message count incremented for both messages
+        mock_session_service.increment_message_count.assert_called_once_with(
+            "test-session", 2
+        )
     
     @pytest.mark.asyncio
     async def test_stream_message_fallback(self, chat_service, mock_llm_service, mock_session_service, mock_history_service):


### PR DESCRIPTION
## Summary
- increment session message count for both user and AI message when streaming
- test that streaming increments count by 2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a8d15a31c832c81c96c0fb1b0d2a8