### PR TITLE
Add streaming support for Google provider

### DIFF
--- a/tests/unit/test_llm_service_stream.py
+++ b/tests/unit/test_llm_service_stream.py
@@ -1,0 +1,24 @@
+import pytest
+
+from backend.services.ai.llm_service import LLMService
+from backend.services.ai.providers.google_provider import GoogleProvider
+
+@pytest.mark.asyncio
+async def test_stream_chat_response_uses_provider(monkeypatch):
+    service = LLMService(db_path=":memory:")
+    assert service.set_active_model("google-gemini-pro")
+
+    provider = GoogleProvider(api_key="test")
+
+    def fake_stream(messages, model_id, params, timeout=60):
+        yield "foo"
+        yield "bar"
+
+    monkeypatch.setattr(service, "_get_provider_instance", lambda name: provider)
+    provider.stream_chat_completion = fake_stream
+
+    chunks = []
+    async for chunk in service.stream_chat_response([{"role": "user", "content": "hi"}]):
+        chunks.append(chunk)
+
+    assert chunks == ["foo", "bar"]


### PR DESCRIPTION
## Summary
- implement a `stream_chat_completion` generator for the Google provider
- add LLMService unit test that verifies streaming via the provider

## Testing
- `pytest -q tests/unit/test_llm_service_stream.py::test_stream_chat_response_uses_provider -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688a8d2d4998832c9c1d73a653c22637