### PR TITLE
Add language context with toggle

### DIFF
--- a/frontend/electron-app/src/renderer/components/layout/header.tsx
+++ b/frontend/electron-app/src/renderer/components/layout/header.tsx
@@ -2,12 +2,20 @@ import React from 'react';
 import { useUIStore } from '../../stores';
 import { Button } from '../ui/button';
 import { Moon, Sun } from 'lucide-react';
+import { useLanguage } from '../../contexts/language-context';
+import { useTranslation } from '../../lib/i18n';
 
 export const Header: React.FC = () => {
   const { theme, setTheme } = useUIStore();
+  const { language, setLanguage } = useLanguage();
+  const { t } = useTranslation();
 
   const toggleTheme = () => {
     setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  const toggleLanguage = () => {
+    setLanguage(language === 'he' ? 'en' : 'he');
   };
 
   return (
@@ -18,6 +26,9 @@ export const Header: React.FC = () => {
       <div>
         <Button variant="ghost" size="icon" onClick={toggleTheme}>
           {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </Button>
+        <Button variant="ghost" size="icon" onClick={toggleLanguage} className="ml-2">
+          {t('toggle_language')}
         </Button>
       </div>
     </header>

--- a/frontend/electron-app/src/renderer/contexts/language-context.tsx
+++ b/frontend/electron-app/src/renderer/contexts/language-context.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useUserStore } from '../stores';
+
+type Language = 'en' | 'he';
+
+interface LanguageContextValue {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue>({
+  language: 'he',
+  setLanguage: () => undefined,
+});
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { updateUserPreferences } = useUserStore();
+  const [language, setLanguageState] = useState<Language>(() => {
+    const stored = localStorage.getItem('language') as Language | null;
+    return stored || 'he';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('language', language);
+    updateUserPreferences({ language });
+  }, [language, updateUserPreferences]);
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/frontend/electron-app/src/renderer/lib/i18n.ts
+++ b/frontend/electron-app/src/renderer/lib/i18n.ts
@@ -1,0 +1,16 @@
+import { dictionaries } from '../locales';
+import { useLanguage } from '../contexts/language-context';
+
+export const t = (key: string, lang: string): string => {
+  const dict = dictionaries[lang] || {};
+  return dict[key] || key;
+};
+
+export const useTranslation = () => {
+  const { language } = useLanguage();
+
+  return {
+    t: (key: string) => t(key, language),
+    language,
+  };
+};

--- a/frontend/electron-app/src/renderer/locales/en.ts
+++ b/frontend/electron-app/src/renderer/locales/en.ts
@@ -1,0 +1,3 @@
+export default {
+  toggle_language: 'עברית',
+};

--- a/frontend/electron-app/src/renderer/locales/he.ts
+++ b/frontend/electron-app/src/renderer/locales/he.ts
@@ -1,0 +1,3 @@
+export default {
+  toggle_language: 'English',
+};

--- a/frontend/electron-app/src/renderer/locales/index.ts
+++ b/frontend/electron-app/src/renderer/locales/index.ts
@@ -1,0 +1,7 @@
+import en from './en';
+import he from './he';
+
+export const dictionaries: Record<string, Record<string, string>> = {
+  en,
+  he,
+};

--- a/frontend/electron-app/src/renderer/providers/app-providers.tsx
+++ b/frontend/electron-app/src/renderer/providers/app-providers.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '../lib/query-client';
 import { ThemeProvider } from '../contexts/theme-provider';
+import { LanguageProvider } from '../contexts/language-context';
 
 interface AppProvidersProps {
   children: React.ReactNode;
@@ -12,11 +13,11 @@ export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-        {children}
-        {/* React Query DevTools - only shows in development */}
-        <ReactQueryDevtools 
-          initialIsOpen={false} 
-        />
+        <LanguageProvider>
+          {children}
+          {/* React Query DevTools - only shows in development */}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </LanguageProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
- provide `LanguageProvider` context with persistence
- add simple translation helper and dictionaries for Hebrew/English
- wrap the app with the new LanguageProvider
- add a language toggle button in header

## Testing
- `npm test` *(fails: 10 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a0e7174832cb66cf63682bc8de9