### PR TITLE
Add simple i18n support

### DIFF
--- a/frontend/electron-app/src/renderer/components/layout/sidebar.tsx
+++ b/frontend/electron-app/src/renderer/components/layout/sidebar.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { useLocale } from '../../contexts/locale-provider';
 
 const Sidebar = () => {
+  const { t, direction } = useLocale();
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-    `block p-4 hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`;
+    `block p-4 hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''} ${
+      direction === 'rtl' ? 'text-right' : ''
+    }`;
 
   return (
-    <div className="w-64 bg-gray-800 text-white">
-      <div className="p-4 font-bold text-lg">Audio-Chat</div>
+    <div className={`w-64 bg-gray-800 text-white ${direction === 'rtl' ? 'text-right' : ''}`}>
+      <div className="p-4 font-bold text-lg">{t('sidebar.title')}</div>
       <nav>
         <ul>
-          <li><NavLink to="/" className={navLinkClass}>Home</NavLink></li>
-          <li><NavLink to="/terminal" className={navLinkClass}>Terminal</NavLink></li>
-          <li><NavLink to="/chat" className={navLinkClass}>Chat</NavLink></li>
-          <li><NavLink to="/audio" className={navLinkClass}>Audio</NavLink></li>
-          <li><NavLink to="/export" className={navLinkClass}>Export</NavLink></li>
-          <li><NavLink to="/stats" className={navLinkClass}>Stats</NavLink></li>
-          <li><NavLink to="/llm" className={navLinkClass}>LLM Manager</NavLink></li>
-          <li><NavLink to="/testing" className={navLinkClass}>Testing</NavLink></li>
-          <li><NavLink to="/profile" className={navLinkClass}>Profile</NavLink></li>
-          <li><NavLink to="/settings" className={navLinkClass}>Settings</NavLink></li>
+          <li><NavLink to="/" className={navLinkClass}>{t('sidebar.home')}</NavLink></li>
+          <li><NavLink to="/terminal" className={navLinkClass}>{t('sidebar.terminal')}</NavLink></li>
+          <li><NavLink to="/chat" className={navLinkClass}>{t('sidebar.chat')}</NavLink></li>
+          <li><NavLink to="/audio" className={navLinkClass}>{t('sidebar.audio')}</NavLink></li>
+          <li><NavLink to="/export" className={navLinkClass}>{t('sidebar.export')}</NavLink></li>
+          <li><NavLink to="/stats" className={navLinkClass}>{t('sidebar.stats')}</NavLink></li>
+          <li><NavLink to="/llm" className={navLinkClass}>{t('sidebar.llm')}</NavLink></li>
+          <li><NavLink to="/testing" className={navLinkClass}>{t('sidebar.testing')}</NavLink></li>
+          <li><NavLink to="/profile" className={navLinkClass}>{t('sidebar.profile')}</NavLink></li>
+          <li><NavLink to="/settings" className={navLinkClass}>{t('sidebar.settings')}</NavLink></li>
         </ul>
       </nav>
     </div>

--- a/frontend/electron-app/src/renderer/contexts/locale-provider.tsx
+++ b/frontend/electron-app/src/renderer/contexts/locale-provider.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useState } from 'react';
+import en from '../locales/en.json';
+import he from '../locales/he.json';
+
+export type Locale = 'en' | 'he';
+
+const translations = { en, he } as const;
+
+interface LocaleProviderState {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+  direction: 'ltr' | 'rtl';
+}
+
+const LocaleProviderContext = createContext<LocaleProviderState | undefined>(undefined);
+
+interface LocaleProviderProps {
+  children: React.ReactNode;
+  defaultLocale?: Locale;
+}
+
+export const LocaleProvider: React.FC<LocaleProviderProps> = ({ children, defaultLocale = 'en' }) => {
+  const [locale, setLocale] = useState<Locale>(defaultLocale);
+
+  const t = (key: string): string => {
+    const keys = key.split('.');
+    let result: any = translations[locale];
+    for (const k of keys) {
+      result = result?.[k];
+      if (result === undefined) return key;
+    }
+    return typeof result === 'string' ? result : key;
+  };
+
+  const direction: 'ltr' | 'rtl' = locale === 'he' ? 'rtl' : 'ltr';
+
+  return (
+    <LocaleProviderContext.Provider value={{ locale, setLocale, t, direction }}>
+      {children}
+    </LocaleProviderContext.Provider>
+  );
+};
+
+export const useLocale = () => {
+  const context = useContext(LocaleProviderContext);
+  if (!context) {
+    throw new Error('useLocale must be used within a LocaleProvider');
+  }
+  return context;
+};

--- a/frontend/electron-app/src/renderer/locales/en.json
+++ b/frontend/electron-app/src/renderer/locales/en.json
@@ -1,0 +1,15 @@
+{
+  "sidebar": {
+    "title": "Audio-Chat",
+    "home": "Home",
+    "terminal": "Terminal",
+    "chat": "Chat",
+    "audio": "Audio",
+    "export": "Export",
+    "stats": "Stats",
+    "llm": "LLM Manager",
+    "testing": "Testing",
+    "profile": "Profile",
+    "settings": "Settings"
+  }
+}

--- a/frontend/electron-app/src/renderer/locales/he.json
+++ b/frontend/electron-app/src/renderer/locales/he.json
@@ -1,0 +1,15 @@
+{
+  "sidebar": {
+    "title": "אודיו-צ'אט",
+    "home": "בית",
+    "terminal": "טרמינל",
+    "chat": "צ'אט",
+    "audio": "אודיו",
+    "export": "ייצוא",
+    "stats": "סטטיסטיקה",
+    "llm": "מנהל LLM",
+    "testing": "בדיקות",
+    "profile": "פרופיל",
+    "settings": "הגדרות"
+  }
+}

--- a/frontend/electron-app/src/renderer/providers/app-providers.tsx
+++ b/frontend/electron-app/src/renderer/providers/app-providers.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '../lib/query-client';
 import { ThemeProvider } from '../contexts/theme-provider';
+import { LocaleProvider } from '../contexts/locale-provider';
 
 interface AppProvidersProps {
   children: React.ReactNode;
@@ -11,13 +12,13 @@ interface AppProvidersProps {
 export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-        {children}
-        {/* React Query DevTools - only shows in development */}
-        <ReactQueryDevtools 
-          initialIsOpen={false} 
-        />
-      </ThemeProvider>
+      <LocaleProvider>
+        <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+          {children}
+          {/* React Query DevTools - only shows in development */}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </ThemeProvider>
+      </LocaleProvider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Summary
- add `LocaleProvider` with `useLocale` hook
- translate sidebar menu using `t('sidebar.*')`
- include English and Hebrew locale files
- wrap app with new provider

## Testing
- `npm run lint:fix` *(fails: ESLint config not found)*
- `npm test` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a14c0e4832ca02a9328172692b6