### PR TITLE
Set RTL layout and language

### DIFF
--- a/frontend/electron-app/src/renderer/contexts/language-provider.tsx
+++ b/frontend/electron-app/src/renderer/contexts/language-provider.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Direction = 'ltr' | 'rtl';
+
+interface LanguageProviderProps {
+  children: React.ReactNode;
+  defaultLang?: string;
+  defaultDir?: Direction;
+  storageKey?: string;
+}
+
+interface LanguageContextValue {
+  language: string;
+  direction: Direction;
+  setLanguage: (lang: string, dir?: Direction) => void;
+}
+
+const initialState: LanguageContextValue = {
+  language: 'he',
+  direction: 'rtl',
+  setLanguage: () => null,
+};
+
+const LanguageContext = createContext<LanguageContextValue>(initialState);
+
+export const LanguageProvider: React.FC<LanguageProviderProps> = ({
+  children,
+  defaultLang = 'he',
+  defaultDir = 'rtl',
+  storageKey = 'app-language',
+}) => {
+  const [language, setLanguageState] = useState<string>(
+    () => localStorage.getItem(storageKey) || defaultLang,
+  );
+  const [direction, setDirectionState] = useState<Direction>(
+    () => (localStorage.getItem(`${storageKey}-dir`) as Direction) || defaultDir,
+  );
+
+  useEffect(() => {
+    localStorage.setItem(storageKey, language);
+    localStorage.setItem(`${storageKey}-dir`, direction);
+    document.documentElement.lang = language;
+    document.documentElement.dir = direction;
+  }, [language, direction]);
+
+  const setLanguage = (lang: string, dir?: Direction) => {
+    setLanguageState(lang);
+    setDirectionState(dir ?? (lang === 'he' ? 'rtl' : 'ltr'));
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, direction, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (context === undefined) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+};

--- a/frontend/electron-app/src/renderer/index.html
+++ b/frontend/electron-app/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="he" dir="rtl">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/frontend/electron-app/src/renderer/main.tsx
+++ b/frontend/electron-app/src/renderer/main.tsx
@@ -1,8 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { AppProviders } from './providers/app-providers'; // Import AppProviders
+import { AppProviders } from './providers/app-providers';
+import { useLanguage } from './contexts/language-provider';
+
+const LanguageUpdater: React.FC = () => {
+  const { language, direction } = useLanguage();
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+    document.documentElement.dir = direction;
+  }, [language, direction]);
+
+  return null;
+};
 
 // Ensure we have a root element
 const rootElement = document.getElementById('root');
@@ -14,7 +26,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <AppProviders> {/* Wrap App with AppProviders */}
+    <AppProviders>
+      <LanguageUpdater />
       <App />
     </AppProviders>
   </React.StrictMode>

--- a/frontend/electron-app/src/renderer/providers/app-providers.tsx
+++ b/frontend/electron-app/src/renderer/providers/app-providers.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '../lib/query-client';
 import { ThemeProvider } from '../contexts/theme-provider';
+import { LanguageProvider } from '../contexts/language-provider';
 
 interface AppProvidersProps {
   children: React.ReactNode;
@@ -11,13 +12,13 @@ interface AppProvidersProps {
 export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-        {children}
-        {/* React Query DevTools - only shows in development */}
-        <ReactQueryDevtools 
-          initialIsOpen={false} 
-        />
-      </ThemeProvider>
+      <LanguageProvider>
+        <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+          {children}
+          {/* React Query DevTools - only shows in development */}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </ThemeProvider>
+      </LanguageProvider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Summary
- enable RTL layout by default in the renderer HTML
- provide LanguageProvider context for language and direction
- expose LanguageProvider via AppProviders
- ensure main.tsx updates the document element based on context

## Testing
- `npx vitest run` *(fails: Test Files 10 failed | 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a10cbdc832c818cc99339f29253